### PR TITLE
fix: Resolve OrderService test interference with xUnit collection fixtures

### DIFF
--- a/Maliev.OrderService.Tests/Contract/AdminAccessTests.cs
+++ b/Maliev.OrderService.Tests/Contract/AdminAccessTests.cs
@@ -6,7 +6,7 @@ using Maliev.OrderService.Data.Models;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class AdminAccessTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class AdminAccessTests(TestWebApplicationFactory factory)
     {
         private readonly TestWebApplicationFactory _factory = factory;
         private static readonly string[] AdminRoles = ["admin"];

--- a/Maliev.OrderService.Tests/Contract/BatchOrderEndpointTests.cs
+++ b/Maliev.OrderService.Tests/Contract/BatchOrderEndpointTests.cs
@@ -6,7 +6,7 @@ using Maliev.OrderService.Api.Authorization;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class BatchOrderEndpointTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class BatchOrderEndpointTests(TestWebApplicationFactory factory)
     {
         private readonly TestWebApplicationFactory _factory = factory;
         private readonly HttpClient _client = factory.CreateAuthenticatedClient(

--- a/Maliev.OrderService.Tests/Contract/CreatorOwnershipTests.cs
+++ b/Maliev.OrderService.Tests/Contract/CreatorOwnershipTests.cs
@@ -6,7 +6,7 @@ using Maliev.OrderService.Data;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class CreatorOwnershipTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class CreatorOwnershipTests(TestWebApplicationFactory factory)
     {
         private readonly TestWebApplicationFactory _factory = factory;
         private static readonly string[] ReadPermissions = [OrderPermissions.OrdersRead];

--- a/Maliev.OrderService.Tests/Contract/FileEndpointTests.cs
+++ b/Maliev.OrderService.Tests/Contract/FileEndpointTests.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class FileEndpointTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class FileEndpointTests(TestWebApplicationFactory factory)
     {
         private readonly HttpClient _client = factory.CreateAuthenticatedClient("test-admin", AdminRoles, OrderPermissions.All);
 

--- a/Maliev.OrderService.Tests/Contract/FulfillmentAccessTests.cs
+++ b/Maliev.OrderService.Tests/Contract/FulfillmentAccessTests.cs
@@ -7,7 +7,7 @@ using Maliev.OrderService.Data.Models;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class FulfillmentAccessTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class FulfillmentAccessTests(TestWebApplicationFactory factory)
     {
         private readonly TestWebApplicationFactory _factory = factory;
         private static readonly string[] FulfillmentRoles = ["roles.order.fulfillment"];

--- a/Maliev.OrderService.Tests/Contract/IntegrationScenarioTests.cs
+++ b/Maliev.OrderService.Tests/Contract/IntegrationScenarioTests.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class IntegrationScenarioTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class IntegrationScenarioTests(TestWebApplicationFactory factory)
     {
         private readonly HttpClient _client = factory.CreateAuthenticatedClient("test-admin", AdminRoles, OrderPermissions.All);
         private readonly TestWebApplicationFactory _factory = factory;

--- a/Maliev.OrderService.Tests/Contract/ManagerAccessTests.cs
+++ b/Maliev.OrderService.Tests/Contract/ManagerAccessTests.cs
@@ -7,7 +7,7 @@ using Maliev.OrderService.Data.Models;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class ManagerAccessTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class ManagerAccessTests(TestWebApplicationFactory factory)
     {
         private readonly TestWebApplicationFactory _factory = factory;
 

--- a/Maliev.OrderService.Tests/Contract/NotesEndpointTests.cs
+++ b/Maliev.OrderService.Tests/Contract/NotesEndpointTests.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class NotesEndpointTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class NotesEndpointTests(TestWebApplicationFactory factory)
     {
         private readonly HttpClient _client = factory.CreateAuthenticatedClient("test-admin", AdminRoles, OrderPermissions.All);
 

--- a/Maliev.OrderService.Tests/Contract/OrderEndpointTests.cs
+++ b/Maliev.OrderService.Tests/Contract/OrderEndpointTests.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class OrderEndpointTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class OrderEndpointTests(TestWebApplicationFactory factory)
     {
         private readonly HttpClient _client = factory.CreateAuthenticatedClient("test-admin", AdminRoles, OrderPermissions.All);
 

--- a/Maliev.OrderService.Tests/Contract/StatusEndpointTests.cs
+++ b/Maliev.OrderService.Tests/Contract/StatusEndpointTests.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 namespace Maliev.OrderService.Tests.Contract
 {
     [Collection("Database")]
-    public class StatusEndpointTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+    public class StatusEndpointTests(TestWebApplicationFactory factory)
     {
         private readonly HttpClient _client = factory.CreateAuthenticatedClient("test-admin", AdminRoles, OrderPermissions.All);
 

--- a/Maliev.OrderService.Tests/DatabaseCollection.cs
+++ b/Maliev.OrderService.Tests/DatabaseCollection.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Maliev.OrderService.Tests.Contract;
+
+/// <summary>
+/// xUnit collection definition for sharing a single TestWebApplicationFactory instance across all test classes.
+/// This ensures the test database, Redis, and RabbitMQ containers are created once and reused.
+/// </summary>
+[CollectionDefinition("Database")]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "xUnit collection definition conventionally ends with 'Collection'")]
+public class DatabaseCollection : ICollectionFixture<TestWebApplicationFactory>
+{
+    // This class has no code, and is never instantiated. Its purpose is to define
+    // the collection fixture for xUnit to share a TestWebApplicationFactory instance.
+}


### PR DESCRIPTION
## Summary
Fixes test interference issues in OrderService causing 3 batch tests to fail in full suite despite passing in isolation.

**Test results**: 42/42 passing (100% pass rate)

## Changes Made

### 1. Created DatabaseCollection Class
- Added `DatabaseCollection` class with `ICollectionFixture<TestWebApplicationFactory>`
- Defines xUnit collection fixture for sharing single factory instance across all test classes
- Ensures test database, Redis, and RabbitMQ containers are created once and reused

### 2. Fixed Test Class Declarations
Removed redundant `IClassFixture<TestWebApplicationFactory>` from 10 test classes:
- `BatchOrderEndpointTests`
- `AdminAccessTests`
- `CreatorOwnershipTests`
- `FileEndpointTests`
- `FulfillmentAccessTests`
- `IntegrationScenarioTests`
- `ManagerAccessTests`
- `NotesEndpointTests`
- `OrderEndpointTests`
- `StatusEndpointTests`

### 3. Root Cause
Test classes had both `[Collection("Database")]` and `IClassFixture<TestWebApplicationFactory>`, causing xUnit to:
- Create multiple factory instances instead of sharing one
- Fail with JWT PublicKey configuration errors: "JWT PublicKey not configured. Set Jwt:PublicKey in configuration"

**Solution**: Use Collection fixture for shared instance across all tests, remove individual class fixtures.

## Test Evidence
- All 42 tests pass reliably in full suite
- Batch tests now run successfully alongside other tests
- No more JWT configuration errors

## Related Issues
- Fixes test interference in OrderService
- Resolves batch test failures that only occurred in full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)